### PR TITLE
fix: handle circular Lazy<T> reentrancy in export initialization

### DIFF
--- a/CUE4Parse/UE4/Assets/IoPackage.cs
+++ b/CUE4Parse/UE4/Assets/IoPackage.cs
@@ -242,10 +242,13 @@ public sealed class IoPackage : AbstractUePackage
             {
                 // Create
                 var clas = ResolveObjectIndex(export.ClassIndex);
-                var struc = clas?.Object?.Value as UStruct;
+                UStruct? struc = null;
+                try { struc = clas?.Object?.Value as UStruct; }
+                catch (InvalidOperationException) { /* circular lazy dependency */ }
                 var obj = ConstructObject(struc, this, export.ObjectFlags);
                 obj.Name = CreateFNameFromMappedName(export.ObjectName).Text;
-                obj.Outer = (ResolveObjectIndex(export.OuterIndex) as ResolvedExportObject)?.Object?.Value ?? this;
+                try { obj.Outer = (ResolveObjectIndex(export.OuterIndex) as ResolvedExportObject)?.Object?.Value ?? this; }
+                catch (InvalidOperationException) { obj.Outer = this; }
                 obj.Super = ResolveObjectIndex(export.SuperIndex) as ResolvedExportObject;
                 obj.Template = ResolveObjectIndex(export.TemplateIndex) as ResolvedExportObject;
                 obj.Flags |= export.ObjectFlags; // We give loaded objects the RF_WasLoaded flag in ConstructObject, so don't remove it again in here

--- a/CUE4Parse/UE4/Assets/Package.cs
+++ b/CUE4Parse/UE4/Assets/Package.cs
@@ -200,9 +200,13 @@ namespace CUE4Parse.UE4.Assets
                     ExportsLazy[i] = new Lazy<UObject>(() =>
                     {
                         // Create
-                        var obj = ConstructObject(ResolvePackageIndex(export.ClassIndex)?.Object?.Value as UStruct, this, (EObjectFlags) export.ObjectFlags);
+                        UStruct? struc = null;
+                        try { struc = ResolvePackageIndex(export.ClassIndex)?.Object?.Value as UStruct; }
+                        catch (InvalidOperationException) { /* circular lazy dependency */ }
+                        var obj = ConstructObject(struc, this, (EObjectFlags) export.ObjectFlags);
                         obj.Name = export.ObjectName.Text;
-                        obj.Outer = (ResolvePackageIndex(export.OuterIndex) as ResolvedExportObject)?.Object.Value ?? this;
+                        try { obj.Outer = (ResolvePackageIndex(export.OuterIndex) as ResolvedExportObject)?.Object.Value ?? this; }
+                        catch (InvalidOperationException) { obj.Outer = this; }
                         obj.Super = ResolvePackageIndex(export.SuperIndex) as ResolvedExportObject;
                         obj.Template = ResolvePackageIndex(export.TemplateIndex) as ResolvedExportObject;
                         obj.Flags |= (EObjectFlags) export.ObjectFlags; // We give loaded objects the RF_WasLoaded flag in ConstructObject, so don't remove it again in here


### PR DESCRIPTION
When exports in the same package have circular references (e.g., export
A's outer is export B, which references export A), the Lazy<UObject>
factory throws InvalidOperationException due to reentrant .Value access.
Catch the reentrancy exception and fall back gracefully: null struct for
class resolution, package itself for outer resolution.

https://claude.ai/code/session_01QdvzeKivRSJ8WW7fjzz5gT